### PR TITLE
fix VyperException import

### DIFF
--- a/vyper_lsp/ast.py
+++ b/vyper_lsp/ast.py
@@ -9,7 +9,7 @@ from vyper.compiler.input_bundle import FilesystemInputBundle
 from vyper.compiler.phases import DEFAULT_CONTRACT_PATH, ModuleT
 from vyper.semantics.types import StructT
 from vyper.semantics.types.user import FlagT
-from vyper.utils import VyperException
+from vyper.exceptions import VyperException
 from vyper.cli.vyper_compile import get_search_paths
 import warnings
 import re


### PR DESCRIPTION
Fixes the import error preventing the lsp to run (at least on neovim):

`[ERROR][2025-03-19 14:10:49] .../vim/lsp/rpc.lua:770	"rpc"	"vyper-lsp"	"stderr"	"  File \"/home/salus/si/contracts/.venv/lib/python3.13/site-packages/vyper_lsp/main.py\", line 33, in <module>\n    from vyper_lsp.handlers.signatures import SignatureHandler\n  File \"/home/salus/si/contracts/.venv/lib/python3.13/site-packages/vyper_lsp/handlers/signatures.py\", line 14, in <module>\n    from vyper_lsp.ast import AST\n  File \"/home/salus/si/contracts/.venv/lib/python3.13/site-packages/vyper_lsp/ast.py\", line 12, in <module>\n    from vyper.utils import VyperException\nImportError: cannot import name 'VyperException' from 'vyper.utils' (/home/salus/si/contracts/.venv/lib/python3.13/site-packages/vyper/utils.py)\n"`
