### PR TITLE
Fix self. completions to exclude constants and immutables

### DIFF
--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -148,3 +148,36 @@ def bar():
     assert "view" in labels
     assert "pure" in labels
     assert "deploy" in labels
+
+
+def test_self_completions_exclude_constants_and_immutables(ast):
+    """Constants and immutables should not appear in self. completions."""
+    src = """#pragma version ^0.4.0
+
+counter: uint256
+MY_CONST: constant(uint256) = 100
+my_immut: immutable(uint256)
+
+@deploy
+def __init__():
+    my_immut = 42
+
+@internal
+def _foo():
+    pass
+"""
+    ast.build_ast(src)
+    handler = CompletionHandler(ast)
+
+    completions = handler._dot_completions_for_element("self")
+    labels = [item.label for item in completions]
+
+    # State variable should be included
+    assert "counter" in labels
+
+    # Internal function should be included
+    assert "_foo" in labels
+
+    # Constants and immutables should NOT be included
+    assert "MY_CONST" not in labels
+    assert "my_immut" not in labels

--- a/vyper_lsp/ast.py
+++ b/vyper_lsp/ast.py
@@ -217,14 +217,15 @@ class AST:
         return [node.target.id for node in struct_node.get_children(nodes.AnnAssign)]
 
     def get_state_variables(self):
+        return [node.target.id for node in self.get_state_variables_as_vardecls()]
+
+    def get_state_variables_as_vardecls(self):
         # NOTE: The state variables should be fetched from self.ast_data, they are
         # missing from self.ast_data_unfolded and self.ast_data_folded when constants
         if self.ast_data is None:
             return []
 
-        return [
-            node.target.id for node in self.ast_data.get_descendants(nodes.VariableDecl)
-        ]
+        return self.ast_data.get_descendants(nodes.VariableDecl)
 
     def get_internal_function_nodes(self):
         function_nodes = self.get_descendants(nodes.FunctionDef)

--- a/vyper_lsp/handlers/completion.py
+++ b/vyper_lsp/handlers/completion.py
@@ -102,9 +102,15 @@ class CompletionHandler:
         if element == "self":
             for fn in self.ast.get_internal_functions():
                 completions.append(CompletionItem(label=fn))
-            # TODO: This should exclude constants and immutables
-            for var in self.ast.get_state_variables():
-                completions.append(CompletionItem(label=var))
+
+            for var in self.ast.get_state_variables_as_vardecls():
+
+                # In Vyper, immutable and/or constant variables can not be accessed via
+                # self. so we should exclude them here
+                if var.is_constant or var.is_immutable:
+                    continue
+
+                completions.append(CompletionItem(label=var.target.id))
         elif self.ast.imports and element in self.ast.imports.keys():
             completions = self._dot_completions_for_module(
                 element, top_level_node=top_level_node, line=line


### PR DESCRIPTION
 - Constants and immutables cannot be accessed via self. in Vyper, but they were incorrectly appearing in autocomplete
 - Added `get_state_variables_as_vardecls()` method to expose full `VariableDecl` nodes
 - Filter out variables where `is_constant` or `is_immutable` is true from self. completions
 - Added `test_self_completions_exclude_constants_and_immutables` to verify solution